### PR TITLE
Bug fix for deletion

### DIFF
--- a/lib/rb_tree.ex
+++ b/lib/rb_tree.ex
@@ -529,7 +529,7 @@ defmodule RedBlackTree do
                 right: right_node.left.left
             },
             %{right_node.left | left: nil, right: nil},
-            right_node.left.left
+            right_node.left.right
           )
     }
   end


### PR DESCRIPTION
Typo: the same node (right_node.left.left) was included twice in the resulting tree!  Verified by consultation with Fig 9 in https://matt.might.net/papers/germane2014deletion.pdf